### PR TITLE
use static buffers for w_ReadLump/DecodeD64

### DIFF
--- a/doom64/decodes.c
+++ b/doom64/decodes.c
@@ -41,7 +41,8 @@ static short DecodeTable[2524]; // 800B22A8
 static short array01[1258];     // 800B3660
 
 static decoder_t decoder;       // 800B4034
-static byte *allocPtr;          // 800B4054
+static u64 allocBuf[8192];
+static byte *allocPtr = (byte*)allocBuf;          // 800B4054
 
 static int OVERFLOW_READ;       // 800B4058
 static int OVERFLOW_WRITE;      // 800B405C
@@ -725,8 +726,6 @@ void DecodeD64(unsigned char *input, unsigned char *output) // 8002DFA0
 	decoder.write = output;
 	decoder.writePos = output;
 
-	allocPtr = (byte *)Z_Alloc(tableVar01[13], PU_STATIC, NULL);
-
     dec_byte = StartDecodeByte();
 
     while(dec_byte != 256)
@@ -804,8 +803,6 @@ void DecodeD64(unsigned char *input, unsigned char *output) // 8002DFA0
 
         dec_byte = StartDecodeByte();
     }
-
-	Z_Free(allocPtr);
 
 	//PRINTF_D2(WHITE, 0, 21, "DecodeD64:End");
 }

--- a/doom64/w_wad.c
+++ b/doom64/w_wad.c
@@ -210,11 +210,13 @@ int W_LumpLength (int lump) // 8002C204
 =
 ====================
 */
+// 128 kb buffer to replace Z_Alloc in W_ReadLump
+static u64 input_w_readlump[16384]; 
+static byte *input = (byte*)input_w_readlump;
 
 void W_ReadLump (int lump, void *dest, decodetype dectype) // 8002C260
 {
     OSIoMesg romio_msgbuf;
-	byte *input;
 	lumpinfo_t *l;
 	int lumpsize;
 
@@ -227,7 +229,6 @@ void W_ReadLump (int lump, void *dest, decodetype dectype) // 8002C260
 		if ((l->name[0] & 0x80)) /* compressed */
 		{
 			lumpsize = l[1].filepos - (l->filepos);
-			input = Z_Alloc(lumpsize, PU_STATIC, NULL);
 
 			osInvalDCache((void *)input, lumpsize);
 
@@ -242,7 +243,6 @@ void W_ReadLump (int lump, void *dest, decodetype dectype) // 8002C260
 			else // dec_d64
 				DecodeD64((byte *)input, (byte *)dest);
 
-			Z_Free(input);
 			return;
 		}
 	}


### PR DESCRIPTION
Trying to stop zone heap fragmentation by getting rid of the use of repeated small Z_Alloc/Z_Free in W_ReadLump and DecodeD64. 